### PR TITLE
Report only the version number without such ruby prefix for Ruby repositories

### DIFF
--- a/lib/blakey/repository/ruby/ruby_version_fetcher.rb
+++ b/lib/blakey/repository/ruby/ruby_version_fetcher.rb
@@ -10,12 +10,20 @@ module Blakey
       end
 
       def version
-        gemfile_lock_parser.ruby_version || fetch_version_from_ruby_version_file
+        format_version(fetched_version)
       end
 
       private
 
       attr_reader :gemfile_lock_parser, :source
+
+      def format_version(version_string)
+        version_string.gsub(/^(.*?)(?=[0-9])/, '').strip
+      end
+
+      def fetched_version
+        gemfile_lock_parser.ruby_version || fetch_version_from_ruby_version_file
+      end
 
       def fetch_version_from_ruby_version_file
         source.read_file('.ruby-version')

--- a/spec/blakey/repository/ruby/ruby_version_fetcher_spec.rb
+++ b/spec/blakey/repository/ruby/ruby_version_fetcher_spec.rb
@@ -24,6 +24,14 @@ describe Blakey::Repository::Ruby::GemfileLockParser do
 
         expect(subject.version).to eq('2.7.1')
       end
+
+      context 'when the version contains ruby prefix' do
+        before { allow(gemfile_lock_parser).to receive(:ruby_version).and_return('ruby 2.7.1p157') }
+
+        it 'returns the version number only without the ruby prefix' do
+          expect(subject.version).to eq('2.7.1p157')
+        end
+      end
     end
 
     context 'when gemfile lock does not have ruby version' do
@@ -33,6 +41,14 @@ describe Blakey::Repository::Ruby::GemfileLockParser do
         expect(source).to receive(:read_file).with('.ruby-version')
 
         expect(subject.version).to eq('2.6.5')
+      end
+
+      context 'when the version contains ruby prefix' do
+        before { allow(source).to receive(:read_file).with('.ruby-version').and_return('ruby 2.6.5p50') }
+
+        it 'returns the version number only without the ruby prefix' do
+          expect(subject.version).to eq('2.6.5p50')
+        end
       end
     end
   end


### PR DESCRIPTION
This ensures that such instances of a version reported from the Gemfile like 'ruby 2.7.1' are returned just like '2.7.1'

Resolves #1